### PR TITLE
Add Pine Script version 4

### DIFF
--- a/syntaxes/pine.tmLanguage.json
+++ b/syntaxes/pine.tmLanguage.json
@@ -72,7 +72,47 @@
     "functions": {
       "patterns": [
         {
-          "match": "\\b(avg|bar(color|since)|bgcolor|change|cross|donchian|falling|fill|highest|iff|input|lowest|m(ax|in)|plot(arrow|bar|candle|char|shape|figure)?|rising|security|tostring|(e|s)ma|study|valuewhen)(?=\\()",
+          "match": "\\b(abs|acos|alertcondition|alma|asin|atan|atr|avg|barcolor|barssince|bb|bbw|bgcolor|bool|cci|ceil|change|cmo|cog|color|color\\.new|correlation|cos|cross|crossover|crossunder|cum|dayofmonth|dayofweek|dev|dmi|ema|exp|falling|fill|financial|fixnan|float|floor|heikinashi|highest|highestbars|hline|hma|hour|iff|input|int|kagi|kc|kcw|label|line|linebreak|linreg|log|log10|lowest|lowestbars|macd|max|max_bars_back|mfi|min|minute|mom|month|na|nz|offset|percentile_linear_interpolation|percentile_nearest_rank|pivothigh|pivotlow|plot|plotarrow|plotbar|plotcandle|plotchar|plotshape|pointfigure|pow|quandl|renko|rising|rma|roc|round|rsi|sar|second|security|sign|sin|sma|sqrt|stdev|stoch|str\\.replace_all|strategy|string|study|sum|supertrend|swma|tan|tickerid|time|timestamp|tostring|tr|tsi|valuewhen|variance|vwma|weekofyear|wma|wpr|year)(?=\\()",
+          "captures": {
+						"1": { 
+								"name": "support.function.pine" 
+						}
+					}
+        },
+        {
+          "match": "\\barray\\.(avg|clear|concat|copy|covariance|fill|get|includes|indexof|insert|lastindexof|max|median|min|mode|new_bool|new_color|new_float|new_int|pop|push|remove|reverse|set|shift|size|slice|sort|standardize|stdev|sum|unshift|variance)(?=\\()",
+          "captures": {
+						"1": { 
+								"name": "support.function.pine" 
+						}
+					}
+        },
+        {
+          "match": "\\blabel\\.(delete|get_text|get_x|get_y|new|set_color|set_size|set_text|set_textalign|set_textcolor|set_tooltip|set_x|set_xloc|set_xy|set_y|set_yloc)(?=\\()",
+          "captures": {
+						"1": { 
+								"name": "support.function.pine" 
+						}
+					}
+        },
+        {
+          "match": "\\bline\\.(delete|get_price|get_x1|get_x2|get_y1|get_y2|new|set_color|set_extend|set_style|set_width|set_x1|set_x2|set_xloc|set_xy1|set_xy2|set_y1|set_y2)(?=\\()",
+          "captures": {
+						"1": { 
+								"name": "support.function.pine" 
+						}
+					}
+        },
+        {
+          "match": "\\bstrategy\\.(cancel|cancel_all|close|close_all|entry|exit|order)(?=\\()",
+          "captures": {
+						"1": { 
+								"name": "support.function.pine" 
+						}
+					}
+        },
+        {
+          "match": "\\bstrategy\\.risk\\.(allow_entry_in|max_cons_loss_days|max_drawdown|max_intraday_filled_orders|max_intraday_loss|max_position_size)(?=\\()",
           "captures": {
 						"1": { 
 								"name": "support.function.pine" 
@@ -103,15 +143,23 @@
           "name": "constant.language.pine"
         },
         {
-          "match": "\\b(open|high|low|close|volume|na|len|period|tikerid)\\b",
+          "match": "\\b(accdist|bar_index|close|dayofmonth|dayofweek|high|hl2|hlc3|hour|iii|low|minute|month|na|nvi|obv|ohlc4|open|pvi|pvt|second|time|time_close|timenow|tr|volume|vwap|wad|weekofyear|wvad|year|)\\b",
           "name": "constant.language.pine"
         },
         {
-          "match": "\\b(monday|tuesday|wednesday|thursday|friday|saturday|sunday|dayofweek)\\b",
+          "match": "\\btimeframe\\.(isdaily|isdwm|isintraday|isminutes|ismonthly|isseconds|isweekly|multiplier|period)\\b",
           "name": "constant.language.pine"
         },
         {
-          "match": "\\b(line|histogram|cross|area|columns|circles)\\b",
+          "match": "\\bsyminfo\\.(basecurrency|currency|description|mintick|pointvalue|prefix|root|session|ticker|tickerid|timezone|type)\\b",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\bdayofweek\\.(monday|tuesday|wednesday|thursday|friday|saturday|sunday)\\b",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\bplot\\.style_(area|areabr|circles|columns|cross|histogram|line|linebr|stepline)\\b",
           "name": "constant.language.pine"
         },
         {
@@ -119,11 +167,103 @@
           "name": "constant.language.pine"
         },
         {
-          "match": "\\bshape\\.(x(cross)?|(triangle|arrow|label)(up|down)|flag|circle|square|diamond)\\b",
+          "match": "\\bshape\\.(arrowdown|arrowup|circle|cross|diamond|flag|labeldown|labelup|square|triangledown|triangleup|xcross)\\b",
           "name": "constant.language.pine"
         },
         {
-          "match": "\\b(aqua|black|silver|gray|white|maroon|red|purple|fuchsia|green|lime|olive|yellow|navy|blue|teal|orange)\\b",
+          "match": "\\bcolor\\.(aqua|black|silver|gray|white|maroon|red|purple|fuchsia|green|lime|olive|yellow|navy|blue|teal|orange)\\b",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\bcurrency\\.(AUD|CAD|CHF|EUR|GBP|HKD|JPY|NOK|NONE|NZD|RUB|SEK|SGD|TRY|USD|ZAR)\\b",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\bbarmerge\\.(gaps_off|gaps_on|lookahead_off|lookahead_on)\\b",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\bbarstate\\.(isconfirmed|isfirst|ishistory|islast|isnew|isrealtime)\\b",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\badjustment\\.(dividends|none|splits)\\b",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\bdisplay\\.(all|none)\\b",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\bextend\\.(both|left|none|right)\\b",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\bformat\\.(inherit|price|volume)\\b",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\bhline\\.style_(dashed|dotted|solid)\\b",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\binput\\.(bool|color|float|integer|resolution|session|source|string|symbol)\\b",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\blabel\\.style_(arrowdown|arrowup|circle|cross|diamond|flag|label_center|label_down|label_left|label_lower_left|label_lower_right|label_right|label_up|label_upper_left|label_upper_right|none|square|triangledown|triangleup|xcross)\\b",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\bline\\.style_(arrow_both|arrow_left|arrow_right|dashed|dotted|solid)\\b",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\border\\.(ascending|descending)\\b",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\bscale\\.(left|right|none)\\b",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\bsession\\.(extended|regular)\\b",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\bsize\\.(auto|huge|large|normal|small|tiny)\\b",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\bstrategy\\.(cash|closedtrades|equity|eventrades|fixed|grossloss|grossprofit|initial_capital|long|losstrades|max_drawdown|netprofit|openprofit|opentrades|percent_of_equity|position_avg_price|position_entry_name|position_size|short|wintrades)\\b",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\bstrategy\\.commission\\.(cash_per_contract|cash_per_order|percent)\\b",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\bstrategy\\.direction\\.(all|long|short)\\b",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\bstrategy\\.max_contracts_held_(all|long|short)\\b",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\bstrategy\\.oca\\.(cancel|none|reduce)\\b",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\btext\\.align_(center|left|right)\\b",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\bxloc\\.(bar_index|bar_time)\\b",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\byloc\\.(abovebar|belowbar|price)\\b",
           "name": "constant.language.pine"
         },
         {


### PR DESCRIPTION
This PR adds support for Pine Script v4 to the syntax highlight (as discussed in #4), both the functions as well as the built-in variables.

If you have any questions or comments, or see room for improvement, let me know. :slightly_smiling_face: 

Thanks in advance for looking at this pull request.

----
Closes #4 