### PR TITLE
Added basic PineScript 5 syntax.

### DIFF
--- a/syntaxes/pine.tmLanguage.json
+++ b/syntaxes/pine.tmLanguage.json
@@ -1,196 +1,196 @@
 {
-    "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-    "name": "Pine Script",
-    "patterns": [
-        {
-            "match": "//.*",
-            "name": "comment.line.double-slash.pine"
-        },
-        {
-            "include": "#strings"
-        },
-        {
-            "include": "#keywords"
-        },
-        {
-            "include": "#constants"
-        },
-        {
-            "include": "#variables"
-        },
-        {
-            "include": "#functions"
-        },
-        {
-            "include": "#operators"
-        }
-    ],
-    "repository": {
-        "strings": {
-            "patterns": [
-                {
-                    "begin": "\"",
-                    "beginCaptures": {
-                        "1": {
-                            "name": "punctuation.definition.string.begin.pine"
-                        }
-                    },
-                    "end": "\"",
-                    "endCaptures": {
-                        "1": {
-                            "name": "punctuation.definition.string.end.pine"
-                        }
-                    },
-                    "name": "string.quoted.double.pine",
-                    "patterns": [
-                        {
-                            "match": "\\\\.",
-                            "name": "constant.character.escaped.pine"
-                        }
-                    ]
-                },
-                {
-                    "begin": "'",
-                    "beginCaptures": { 
-                        "1": {
-                            "name": "punctuation.definition.string.begin.pine"
-                        }
-                    },
-                    "end": "'",
-                    "endCaptures": {
-                        "1": {
-                            "name": "punctuation.definition.string.end.pine"
-                        }
-                    },
-                    "name": "string.quoted.single.pine",
-                    "patterns": [
-                        {
-                            "match": "\\\\.",
-                            "name": "constant.character.escaped.pine"
-                        }
-                    ]
-                }
-            ]
-        },
-        "keywords": {
-            "patterns": [
-                {
-                    "match": "\\b(if|else|continue|break|for|while|return|export|import|as)\\b",
-                    "name": "keyword.control.pine"
-                }
-            ]
-        },
-        "constants": {
-            "patterns": [
-                {
-                    "match": "\\b(ta|math|input|array|label|adjustment|barmerge|barstate|currency|color|format|location|scale|session|shape|size|strategy|syminfo)\\b(?!\\()(?=\\.)",
-                    "name": "support.class.pine"
-                },
-                {
-                    "match": "\\b(risk|commission|direction|oca)\\b(?!\\()(?=\\.)",
-                    "name": "support.class.pine"
-                },
-                {
-                    "match": "\\b(true|false)\\b(?!\\()",
-                    "name": "constant.language.pine"
-                },
-                {
-                    "match": "\\b(open|high|low|close|volume|na|period)\\b(?!\\()",
-                    "name": "constant.language.pine"
-                },
-                {
-                    "match": "\\b(monday|tuesday|wednesday|thursday|friday|saturday|sunday|second|minute|hour|month|dayofweek|dayofmonth|weekofyear|year)\\b(?!\\()",
-                    "name": "constant.language.pine"
-                },
-                {
-                    "match": "\\b(line|linebr|histogram|cross|area|areabr|columns|circles)\\b(?!\\()",
-                    "name": "constant.language.pine"
-                },
-                {
-                    "match": "\\bis(daily|dwm|intraday|minutes|monthly|seconds|weekly)?\\b(?!\\()",
-                    "name": "constant.language.pine"
-                },
-                {
-                    "match": "\\b(string|symbol|bool|integer|int|float|simple|series)\\b(?!\\()",
-                    "name": "constant.language.pine"
-                },
-                {
-                    "match": "\\b(dotted|dashed)\\b(?!\\()",
-                    "name": "constant.language.pine"
-                },
-                {
-                    "match": "\\b(aqua|black|silver|gray|white|maroon|red|purple|fuchsia|green|lime|olive|yellow|navy|blue|teal|orange)\\b(?!\\()",
-                    "name": "constant.language.pine"
-                },
-                {
-                    "match": "\\b(accdist|hl2|hlc3|interval|n|ohlc4|resolution|session|solid|source|stepline|ticker|tickerid|time|timenow|tr|vwap)\\b(?!\\()",
-                    "name": "constant.language.pine"
-                },
-                {
-                    "match": "\\b(dividends|none|splits|gaps_off|gaps_on|lookahead_off|lookahead_on|isconfirmed|isfirst|ishistory|islast|isnew|isrealtime|AUD|CAD|CHF|EUR|GBP|HKD|JPY|NOK|NONE|NZD|RUB|SEK|SGD|TRY|USD|ZAR|abovebar|absolute|belowbar|bottom|top|left|right|extended|regular|arrowdown|arrowup|circle|diamond|flag|labeldown|labelup|square|triangledown|triangleup|xcross|auto|huge|large|normal|small|tiny|cash|closedtrades|cash_per_contract|cash_per_order|percent|price|all|long|short|equity|eventrades|fixed|grossloss|grossprofit|initial_capital|losstrades|max_contracts_held_all|max_contracts_held_long|max_contracts_held_short|max_drawdown|netprofit|cancel|reduce|openprofit|opentrades|percent_of_equity|position_avg_price|position_entry_name|position_size|wintrades|mintick|pointvalue|prefix|root|timezone)\\b(?!\\()",
-                    "name": "constant.language.pine"
-                },
-                {
-                    "match": "\\b([0-9]+)\\b",
-                    "name": "constant.numeric.pine"
-                },
-                {
-                    "match": "#[a-fA-F0-9]{6}",
-                    "name": "contstant.other.pine"
-                }
-            ]
-        },
-        "variables": {
-            "patterns": [
-                {
-                    "match": "[a-zA-Z_][a-zA-Z0-9_]*\\s*(?=\\=)",
-                    "name": "variable.other.pine"
-                }
-            ]
-        },
-        "functions": {
-            "patterns": [
-                {
-                    "match": "\\b(abs|acros|alertcondition|alma|asin|atan|atr|avg|barcolor|barssince|bgcolor|cci|ceil|change|cog|color|correlation|cos|cross|crossover|crossunder|cum|dayofmonth|dayofweek|dev|ema|exp|falling|fill|fixnan|floor|heikinashi|highest|highestbars|hline|hour|iff|indicator|input|kagi|library|linebreak|linreg|log|log10|lowest|lowestbars|macd|max|min|minute|mom|month|na|nz|offset|percentile_linear_interpolation|percentile_nearest_rank|percentrank|pivothigh|pivotlow|plot(arrow|bar|candle|char|shape)?|pointfigure|pow|renko|rising|rma|roc|round|rsi|sar|second|security|sign|sin|sma|sqrt|stdev|stoch|strategy|cancel|cancel_all|close|close_all|entry|exit|order|allow_entry_in|max_cons_loss_days|max_intraday_filled_orders|max_intraday_loss|max_position_size|study|sum|swma|tan|tickerid|time|timestamp|tostring|tr|tsi|valuewhen|variance|vwap|vwma|weekofyear|wma|year)+?(?=\\()",
-                    "name": "entity.name.function.pine"
-                },
-                {
-                    "match": "([a-zA-Z_][a-zA-Z0-9_]*)\\(.*\\)\\s(=>)\\s",
-                    "captures": {
-                        "1": {
-                            "name": "support.function.pine"
-                        },
-                        "2": {
-                            "name": "keyword.operator.assignment.pine"
-                        }
-                    }
-                }
-            ]
-        },
-        "operators": {
-            "patterns": [
-                {
-                    "match": "(\\-|\\+|\\*|/|%)",
-                    "name": "keyword.operator.arithmetic.pine"
-                },
-                {
-                    "match": "(==|!=|<=|>=|<|>)",
-                    "name": "keyword.operator.comparison.pine"
-                },
-                {
-                    "match": "(\\?|\\:)",
-                    "name": "keyword.operator.ternary.pine"
-                },
-                {
-                    "match": "\\b(and|or|not)\\b",
-                    "name": "keyword.operator.logical.pine"
-                },
-                {
-                    "match": "=",
-                    "name": "keyword.operator.assignment.pine"
-                }
-            ]
-        }
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Pine Script",
+  "patterns": [
+    {
+      "match": "//.*",
+      "name": "comment.line.double-slash.pine"
     },
-    "scopeName": "source.pine"
+    {
+      "include": "#strings"
+    },
+    {
+      "include": "#keywords"
+    },
+    {
+      "include": "#constants"
+    },
+    {
+      "include": "#variables"
+    },
+    {
+      "include": "#functions"
+    },
+    {
+      "include": "#operators"
+    }
+  ],
+  "repository": {
+    "strings": {
+      "patterns": [
+        {
+          "begin": "\"",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.begin.pine"
+            }
+          },
+          "end": "\"",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.end.pine"
+            }
+          },
+          "name": "string.quoted.double.pine",
+          "patterns": [
+            {
+              "match": "\\\\.",
+              "name": "constant.character.escaped.pine"
+            }
+          ]
+        },
+        {
+          "begin": "'",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.begin.pine"
+            }
+          },
+          "end": "'",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.end.pine"
+            }
+          },
+          "name": "string.quoted.single.pine",
+          "patterns": [
+            {
+              "match": "\\\\.",
+              "name": "constant.character.escaped.pine"
+            }
+          ]
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "match": "\\b(if|else|continue|break|for|while|return|export|import|as)\\b",
+          "name": "keyword.control.pine"
+        }
+      ]
+    },
+    "constants": {
+      "patterns": [
+        {
+          "match": "\\b(ta|math|input|array|label|adjustment|barmerge|barstate|currency|color|format|location|scale|session|shape|size|strategy|syminfo)\\b(?!\\()(?=\\.)",
+          "name": "support.class.pine"
+        },
+        {
+          "match": "\\b(risk|commission|direction|oca)\\b(?!\\()(?=\\.)",
+          "name": "support.class.pine"
+        },
+        {
+          "match": "\\b(true|false)\\b(?!\\()",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\b(open|high|low|close|volume|na|period)\\b(?!\\()",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\b(monday|tuesday|wednesday|thursday|friday|saturday|sunday|second|minute|hour|month|dayofweek|dayofmonth|weekofyear|year)\\b(?!\\()",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\b(line|linebr|histogram|cross|area|areabr|columns|circles)\\b(?!\\()",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\bis(daily|dwm|intraday|minutes|monthly|seconds|weekly)?\\b(?!\\()",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\b(string|symbol|bool|integer|int|float|simple|series)\\b(?!\\()",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\b(dotted|dashed)\\b(?!\\()",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\b(aqua|black|silver|gray|white|maroon|red|purple|fuchsia|green|lime|olive|yellow|navy|blue|teal|orange)\\b(?!\\()",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\b(accdist|hl2|hlc3|interval|n|ohlc4|resolution|session|solid|source|stepline|ticker|tickerid|time|timenow|tr|vwap)\\b(?!\\()",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\b(dividends|none|splits|gaps_off|gaps_on|lookahead_off|lookahead_on|isconfirmed|isfirst|ishistory|islast|isnew|isrealtime|AUD|CAD|CHF|EUR|GBP|HKD|JPY|NOK|NONE|NZD|RUB|SEK|SGD|TRY|USD|ZAR|abovebar|absolute|belowbar|bottom|top|left|right|extended|regular|arrowdown|arrowup|circle|diamond|flag|labeldown|labelup|square|triangledown|triangleup|xcross|auto|huge|large|normal|small|tiny|cash|closedtrades|cash_per_contract|cash_per_order|percent|price|all|long|short|equity|eventrades|fixed|grossloss|grossprofit|initial_capital|losstrades|max_contracts_held_all|max_contracts_held_long|max_contracts_held_short|max_drawdown|netprofit|cancel|reduce|openprofit|opentrades|percent_of_equity|position_avg_price|position_entry_name|position_size|wintrades|mintick|pointvalue|prefix|root|timezone)\\b(?!\\()",
+          "name": "constant.language.pine"
+        },
+        {
+          "match": "\\b([0-9]+)\\b",
+          "name": "constant.numeric.pine"
+        },
+        {
+          "match": "#[a-fA-F0-9]{6}",
+          "name": "contstant.other.pine"
+        }
+      ]
+    },
+    "variables": {
+      "patterns": [
+        {
+          "match": "[a-zA-Z_][a-zA-Z0-9_]*\\s*(?=\\=)",
+          "name": "variable.other.pine"
+        }
+      ]
+    },
+    "functions": {
+      "patterns": [
+        {
+          "match": "\\b(abs|acros|alertcondition|alma|asin|atan|atr|avg|barcolor|barssince|bgcolor|cci|ceil|change|cog|color|correlation|cos|cross|crossover|crossunder|cum|dayofmonth|dayofweek|dev|ema|exp|falling|fill|fixnan|floor|heikinashi|highest|highestbars|hline|hour|iff|indicator|input|kagi|library|linebreak|linreg|log|log10|lowest|lowestbars|macd|max|min|minute|mom|month|na|nz|offset|percentile_linear_interpolation|percentile_nearest_rank|percentrank|pivothigh|pivotlow|plot(arrow|bar|candle|char|shape)?|pointfigure|pow|renko|rising|rma|roc|round|rsi|sar|second|security|sign|sin|sma|sqrt|stdev|stoch|strategy|cancel|cancel_all|close|close_all|entry|exit|order|allow_entry_in|max_cons_loss_days|max_intraday_filled_orders|max_intraday_loss|max_position_size|study|sum|swma|tan|tickerid|time|timestamp|tostring|tr|tsi|valuewhen|variance|vwap|vwma|weekofyear|wma|year)+?(?=\\()",
+          "name": "entity.name.function.pine"
+        },
+        {
+          "match": "([a-zA-Z_][a-zA-Z0-9_]*)\\(.*\\)\\s(=>)\\s",
+          "captures": {
+            "1": {
+              "name": "support.function.pine"
+            },
+            "2": {
+              "name": "keyword.operator.assignment.pine"
+            }
+          }
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "match": "(\\-|\\+|\\*|/|%)",
+          "name": "keyword.operator.arithmetic.pine"
+        },
+        {
+          "match": "(==|!=|<=|>=|<|>)",
+          "name": "keyword.operator.comparison.pine"
+        },
+        {
+          "match": "(\\?|\\:)",
+          "name": "keyword.operator.ternary.pine"
+        },
+        {
+          "match": "\\b(and|or|not)\\b",
+          "name": "keyword.operator.logical.pine"
+        },
+        {
+          "match": "=",
+          "name": "keyword.operator.assignment.pine"
+        }
+      ]
+    }
+  },
+  "scopeName": "source.pine"
 }

--- a/syntaxes/pine.tmLanguage.json
+++ b/syntaxes/pine.tmLanguage.json
@@ -1,196 +1,196 @@
 {
-  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-  "name": "Pine Script",
-  "patterns": [
-    {
-      "match": "//.*",
-      "name": "comment.line.double-slash.pine"
-    },
-    {
-      "include": "#strings"
-    },
-    {
-      "include": "#keywords"
-    },
-    {
-      "include": "#constants"
-    },
-    {
-      "include": "#variables"
-    },
-    {
-      "include": "#functions"
-    },
-    {
-      "include": "#operators"
-    }
-  ],
-  "repository": {
-    "strings": {
-      "patterns": [
-        {
-          "begin": "\"",
-          "beginCaptures": {
-            "1": {
-              "name": "punctuation.definition.string.begin.pine"
-            }
-          },
-          "end": "\"",
-          "endCaptures": {
-            "1": {
-              "name": "punctuation.definition.string.end.pine"
-            }
-          },
-          "name": "string.quoted.double.pine",
-          "patterns": [
-            {
-              "match": "\\\\.",
-              "name": "constant.character.escaped.pine"
-            }
-          ]
-        },
-        {
-          "begin": "'",
-          "beginCaptures": {
-            "1": {
-              "name": "punctuation.definition.string.begin.pine"
-            }
-          },
-          "end": "'",
-          "endCaptures": {
-            "1": {
-              "name": "punctuation.definition.string.end.pine"
-            }
-          },
-          "name": "string.quoted.single.pine",
-          "patterns": [
-            {
-              "match": "\\\\.",
-              "name": "constant.character.escaped.pine"
-            }
-          ]
-        }
-      ]
-    },
-    "keywords": {
-      "patterns": [
-        {
-          "match": "\\b(if|else|continue|break|for|while|return|export|import|as)\\b",
-          "name": "keyword.control.pine"
-        }
-      ]
-    },
-    "constants": {
-      "patterns": [
-        {
-          "match": "\\b(ta|math|input|array|label|adjustment|barmerge|barstate|currency|color|format|location|scale|session|shape|size|strategy|syminfo)\\b(?!\\()(?=\\.)",
-          "name": "support.class.pine"
-        },
-        {
-          "match": "\\b(risk|commission|direction|oca)\\b(?!\\()(?=\\.)",
-          "name": "support.class.pine"
-        },
-        {
-          "match": "\\b(true|false)\\b(?!\\()",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\b(open|high|low|close|volume|na|period)\\b(?!\\()",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\b(monday|tuesday|wednesday|thursday|friday|saturday|sunday|second|minute|hour|month|dayofweek|dayofmonth|weekofyear|year)\\b(?!\\()",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\b(line|linebr|histogram|cross|area|areabr|columns|circles)\\b(?!\\()",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\bis(daily|dwm|intraday|minutes|monthly|seconds|weekly)?\\b(?!\\()",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\b(string|symbol|bool|integer|int|float|simple|series)\\b(?!\\()",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\b(dotted|dashed)\\b(?!\\()",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\b(aqua|black|silver|gray|white|maroon|red|purple|fuchsia|green|lime|olive|yellow|navy|blue|teal|orange)\\b(?!\\()",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\b(accdist|hl2|hlc3|interval|n|ohlc4|resolution|session|solid|source|stepline|ticker|tickerid|time|timenow|tr|vwap)\\b(?!\\()",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\b(dividends|none|splits|gaps_off|gaps_on|lookahead_off|lookahead_on|isconfirmed|isfirst|ishistory|islast|isnew|isrealtime|AUD|CAD|CHF|EUR|GBP|HKD|JPY|NOK|NONE|NZD|RUB|SEK|SGD|TRY|USD|ZAR|abovebar|absolute|belowbar|bottom|top|left|right|extended|regular|arrowdown|arrowup|circle|diamond|flag|labeldown|labelup|square|triangledown|triangleup|xcross|auto|huge|large|normal|small|tiny|cash|closedtrades|cash_per_contract|cash_per_order|percent|price|all|long|short|equity|eventrades|fixed|grossloss|grossprofit|initial_capital|losstrades|max_contracts_held_all|max_contracts_held_long|max_contracts_held_short|max_drawdown|netprofit|cancel|reduce|openprofit|opentrades|percent_of_equity|position_avg_price|position_entry_name|position_size|wintrades|mintick|pointvalue|prefix|root|timezone)\\b(?!\\()",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\b([0-9]+)\\b",
-          "name": "constant.numeric.pine"
-        },
-        {
-          "match": "#[a-fA-F0-9]{6}",
-          "name": "contstant.other.pine"
-        }
-      ]
-    },
-    "variables": {
-      "patterns": [
-        {
-          "match": "[a-zA-Z_][a-zA-Z0-9_]*\\s*(?=\\=)",
-          "name": "variable.other.pine"
-        }
-      ]
-    },
-    "functions": {
-      "patterns": [
-        {
-          "match": "\\b(abs|acros|alertcondition|alma|asin|atan|atr|avg|barcolor|barssince|bgcolor|cci|ceil|change|cog|color|correlation|cos|cross|crossover|crossunder|cum|dayofmonth|dayofweek|dev|ema|exp|falling|fill|fixnan|floor|heikinashi|highest|highestbars|hline|hour|iff|indicator|input|kagi|library|linebreak|linreg|log|log10|lowest|lowestbars|macd|max|min|minute|mom|month|na|nz|offset|percentile_linear_interpolation|percentile_nearest_rank|percentrank|pivothigh|pivotlow|plot(arrow|bar|candle|char|shape)?|pointfigure|pow|renko|rising|rma|roc|round|rsi|sar|second|security|sign|sin|sma|sqrt|stdev|stoch|strategy|cancel|cancel_all|close|close_all|entry|exit|order|allow_entry_in|max_cons_loss_days|max_intraday_filled_orders|max_intraday_loss|max_position_size|study|sum|swma|tan|tickerid|time|timestamp|tostring|tr|tsi|valuewhen|variance|vwap|vwma|weekofyear|wma|year)+?(?=\\()",
-          "name": "entity.name.function.pine"
-        },
-        {
-          "match": "([a-zA-Z_][a-zA-Z0-9_]*)\\(.*\\)\\s(=>)\\s",
-          "captures": {
-            "1": {
-              "name": "support.function.pine"
-            },
-            "2": {
-              "name": "keyword.operator.assignment.pine"
-            }
-          }
-        }
-      ]
-    },
-    "operators": {
-      "patterns": [
-        {
-          "match": "(\\-|\\+|\\*|/|%)",
-          "name": "keyword.operator.arithmetic.pine"
-        },
-        {
-          "match": "(==|!=|<=|>=|<|>)",
-          "name": "keyword.operator.comparison.pine"
-        },
-        {
-          "match": "(\\?|\\:)",
-          "name": "keyword.operator.ternary.pine"
-        },
-        {
-          "match": "\\b(and|or|not)\\b",
-          "name": "keyword.operator.logical.pine"
-        },
-        {
-          "match": "=",
-          "name": "keyword.operator.assignment.pine"
-        }
-      ]
-    }
-  },
-  "scopeName": "source.pine"
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"name": "Pine Script",
+	"patterns": [
+		{
+			"match": "//.*",
+			"name": "comment.line.double-slash.pine"
+		},
+		{
+			"include": "#strings"
+		},
+		{
+			"include": "#keywords"
+		},
+		{
+			"include": "#constants"
+		},
+		{
+			"include": "#variables"
+		},
+		{
+			"include": "#functions"
+		},
+		{
+			"include": "#operators"
+		}
+	],
+	"repository": {
+		"strings": {
+			"patterns": [
+				{
+					"begin": "\"",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.begin.pine"
+						}
+					},
+					"end": "\"",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.end.pine"
+						}
+					},
+					"name": "string.quoted.double.pine",
+					"patterns": [
+						{
+							"match": "\\\\.",
+							"name": "constant.character.escaped.pine"
+						}
+					]
+				},
+				{
+					"begin": "'",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.begin.pine"
+						}
+					},
+					"end": "'",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.string.end.pine"
+						}
+					},
+					"name": "string.quoted.single.pine",
+					"patterns": [
+						{
+							"match": "\\\\.",
+							"name": "constant.character.escaped.pine"
+						}
+					]
+				}
+			]
+		},
+		"keywords": {
+			"patterns": [
+				{
+					"match": "\\b(if|else|continue|break|for|while|return|export|import|as)\\b",
+					"name": "keyword.control.pine"
+				}
+			]
+		},
+		"constants": {
+			"patterns": [
+				{
+					"match": "\\b(ta|math|input|array|label|adjustment|barmerge|barstate|currency|color|format|location|scale|session|shape|size|strategy|syminfo)\\b(?!\\()(?=\\.)",
+					"name": "support.class.pine"
+				},
+				{
+					"match": "\\b(risk|commission|direction|oca)\\b(?!\\()(?=\\.)",
+					"name": "support.class.pine"
+				},
+				{
+					"match": "\\b(true|false)\\b(?!\\()",
+					"name": "constant.language.pine"
+				},
+				{
+					"match": "\\b(open|high|low|close|volume|na|period)\\b(?!\\()",
+					"name": "constant.language.pine"
+				},
+				{
+					"match": "\\b(monday|tuesday|wednesday|thursday|friday|saturday|sunday|second|minute|hour|month|dayofweek|dayofmonth|weekofyear|year)\\b(?!\\()",
+					"name": "constant.language.pine"
+				},
+				{
+					"match": "\\b(line|linebr|histogram|cross|area|areabr|columns|circles)\\b(?!\\()",
+					"name": "constant.language.pine"
+				},
+				{
+					"match": "\\bis(daily|dwm|intraday|minutes|monthly|seconds|weekly)?\\b(?!\\()",
+					"name": "constant.language.pine"
+				},
+				{
+					"match": "\\b(string|symbol|bool|integer|int|float|simple|series)\\b(?!\\()",
+					"name": "constant.language.pine"
+				},
+				{
+					"match": "\\b(dotted|dashed)\\b(?!\\()",
+					"name": "constant.language.pine"
+				},
+				{
+					"match": "\\b(aqua|black|silver|gray|white|maroon|red|purple|fuchsia|green|lime|olive|yellow|navy|blue|teal|orange)\\b(?!\\()",
+					"name": "constant.language.pine"
+				},
+				{
+					"match": "\\b(accdist|hl2|hlc3|interval|n|ohlc4|resolution|session|solid|source|stepline|ticker|tickerid|time|timenow|tr|vwap)\\b(?!\\()",
+					"name": "constant.language.pine"
+				},
+				{
+					"match": "\\b(dividends|none|splits|gaps_off|gaps_on|lookahead_off|lookahead_on|isconfirmed|isfirst|ishistory|islast|isnew|isrealtime|AUD|CAD|CHF|EUR|GBP|HKD|JPY|NOK|NONE|NZD|RUB|SEK|SGD|TRY|USD|ZAR|abovebar|absolute|belowbar|bottom|top|left|right|extended|regular|arrowdown|arrowup|circle|diamond|flag|labeldown|labelup|square|triangledown|triangleup|xcross|auto|huge|large|normal|small|tiny|cash|closedtrades|cash_per_contract|cash_per_order|percent|price|all|long|short|equity|eventrades|fixed|grossloss|grossprofit|initial_capital|losstrades|max_contracts_held_all|max_contracts_held_long|max_contracts_held_short|max_drawdown|netprofit|cancel|reduce|openprofit|opentrades|percent_of_equity|position_avg_price|position_entry_name|position_size|wintrades|mintick|pointvalue|prefix|root|timezone)\\b(?!\\()",
+					"name": "constant.language.pine"
+				},
+				{
+					"match": "\\b([0-9]+)\\b",
+					"name": "constant.numeric.pine"
+				},
+				{
+					"match": "#[a-fA-F0-9]{6}",
+					"name": "contstant.other.pine"
+				}
+			]
+		},
+		"variables": {
+			"patterns": [
+				{
+					"match": "[a-zA-Z_][a-zA-Z0-9_]*\\s*(?=\\=)",
+					"name": "variable.other.pine"
+				}
+			]
+		},
+		"functions": {
+			"patterns": [
+				{
+					"match": "\\b(abs|acros|alertcondition|alma|asin|atan|atr|avg|barcolor|barssince|bgcolor|cci|ceil|change|cog|color|correlation|cos|cross|crossover|crossunder|cum|dayofmonth|dayofweek|dev|ema|exp|falling|fill|fixnan|floor|heikinashi|highest|highestbars|hline|hour|iff|indicator|input|kagi|library|linebreak|linreg|log|log10|lowest|lowestbars|macd|max|min|minute|mom|month|na|nz|offset|percentile_linear_interpolation|percentile_nearest_rank|percentrank|pivothigh|pivotlow|plot(arrow|bar|candle|char|shape)?|pointfigure|pow|renko|rising|rma|roc|round|rsi|sar|second|security|sign|sin|sma|sqrt|stdev|stoch|strategy|cancel|cancel_all|close|close_all|entry|exit|order|allow_entry_in|max_cons_loss_days|max_intraday_filled_orders|max_intraday_loss|max_position_size|study|sum|swma|tan|tickerid|time|timestamp|tostring|tr|tsi|valuewhen|variance|vwap|vwma|weekofyear|wma|year)+?(?=\\()",
+					"name": "entity.name.function.pine"
+				},
+				{
+					"match": "([a-zA-Z_][a-zA-Z0-9_]*)\\(.*\\)\\s(=>)\\s",
+					"captures": {
+						"1": {
+							"name": "support.function.pine"
+						},
+						"2": {
+							"name": "keyword.operator.assignment.pine"
+						}
+					}
+				}
+			]
+		},
+		"operators": {
+			"patterns": [
+				{
+					"match": "(\\-|\\+|\\*|/|%)",
+					"name": "keyword.operator.arithmetic.pine"
+				},
+				{
+					"match": "(==|!=|<=|>=|<|>)",
+					"name": "keyword.operator.comparison.pine"
+				},
+				{
+					"match": "(\\?|\\:)",
+					"name": "keyword.operator.ternary.pine"
+				},
+				{
+					"match": "\\b(and|or|not)\\b",
+					"name": "keyword.operator.logical.pine"
+				},
+				{
+					"match": "=",
+					"name": "keyword.operator.assignment.pine"
+				}
+			]
+		}
+	},
+	"scopeName": "source.pine"
 }

--- a/syntaxes/pine.tmLanguage.json
+++ b/syntaxes/pine.tmLanguage.json
@@ -2,130 +2,161 @@
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 	"name": "Pine Script",
 	"patterns": [
-    {
-      "match": "//.*",
-      "name": "comment.pine"
-    },
-    {
-			"include": "#constants"
-		},
-    {
-			"include": "#functions"
-		},
-    {
-			"include": "#operators"
-		},
-    {
-			"include": "#keywords"
+		{
+			"match": "//.*",
+			"name": "comment.line.double-slash.pine"
 		},
 		{
 			"include": "#strings"
+		},
+		{
+			"include": "#keywords"
+		},
+		{
+			"include": "#constants"
+		},
+		{
+			"include": "#variables"
+		},
+		{
+			"include": "#functions"
+		},
+		{
+			"include": "#operators"
 		}
 	],
 	"repository": {
-    "strings": {
-      "patterns": [
-        {
-          "begin": "\"",
-          "beginCaptures": {
-            "1": {
-              "name": "punctuation.definition.string.begin.pine"
-            }
-          },
-          "end": "\"",
-          "endCaptures": {
-            "1": {
-              "name": "punctuation.definition.string.end.pine"
-            }
-          },
-          "name" : "string.quoted.double.pine",
-          "patterns": [
-            {
-              "match": "\\\\.",
-              "name": "constant.character.escaped.pine"
-            }
-          ]
-        },
-        {
-          "begin": "'",
-          "beginCaptures": {
-            "1": {
+		"strings": {
+			"patterns": [
+				{
+					"begin": "\"",
+					"beginCaptures": {
+						"1": {
 							"name": "punctuation.definition.string.begin.pine"
-            }
-          },
-          "end": "'",
-          "endCaptures": {
-            "1": {
-              "name": "punctuation.definition.string.end.pine"
-            }
-          },
-          "name" : "string.quoted.double.pine",
-          "patterns": [
-            {
-              "match": "\\\\.",
-              "name": "constant.character.escaped.pine"
-            }
-          ]
-        }
-      ]
-    },
-    "functions": {
-      "patterns": [
-        {
-          "match": "\\b(abs|acos|alertcondition|alma|asin|atan|atr|avg|bar(color|since)|bb|bbw|bgcolor|bool|cci|ceil|change|cmo|cog|color|color\\.new|correlation|cos|cross|crossover|crossunder|cum|dayofmonth|dayofweek|dev|dmi|ema|exp|falling|fill|financial|fixnan|float|floor|heikinashi|highest|highestbars|hline|hma|hour|iff|input|int|kagi|kc|kcw|label|line|linebreak|linreg|log|log10|lowest|lowestbars|macd|max|max_bars_back|mfi|min|minute|mom|month|na|nz|offset|percentile_linear_interpolation|percentile_nearest_rank|pivothigh|pivotlow|plot|plotarrow|plotbar|plotcandle|plotchar|plotshape|pointfigure|pow|quandl|renko|rising|rma|roc|round|rsi|sar|second|security|sign|sin|sma|sqrt|stdev|stoch|str\\.replace_all|strategy|string|study|sum|supertrend|swma|tan|tickerid|time|timestamp|tostring|tr|tsi|valuewhen|variance|vwma|weekofyear|wma|wpr|year)(?=\\()",
-          "captures": {
-						"1": {
-								"name": "support.function.pine"
 						}
-					}
-        },
-        {
-          "match": "\\barray\\.(avg|clear|concat|copy|covariance|fill|get|includes|indexof|insert|lastindexof|max|median|min|mode|new_bool|new_color|new_float|new_int|pop|push|remove|reverse|set|shift|size|slice|sort|standardize|stdev|sum|unshift|variance)(?=\\()",
-          "captures": {
+					},
+					"end": "\"",
+					"endCaptures": {
 						"1": {
-								"name": "support.function.pine"
+							"name": "punctuation.definition.string.end.pine"
 						}
-					}
-        },
-        {
-          "match": "\\blabel\\.(delete|get_text|get_x|get_y|new|set_color|set_size|set_text|set_textalign|set_textcolor|set_tooltip|set_x|set_xloc|set_xy|set_y|set_yloc)(?=\\()",
-          "captures": {
+					},
+					"name": "string.quoted.double.pine",
+					"patterns": [
+						{
+							"match": "\\\\.",
+							"name": "constant.character.escaped.pine"
+						}
+					]
+				},
+				{
+					"begin": "'",
+					"beginCaptures": { 
 						"1": {
-								"name": "support.function.pine"
+							"name": "punctuation.definition.string.begin.pine"
 						}
-					}
-        },
-        {
-          "match": "\\bline\\.(delete|get_price|get_x1|get_x2|get_y1|get_y2|new|set_color|set_extend|set_style|set_width|set_x1|set_x2|set_xloc|set_xy1|set_xy2|set_y1|set_y2)(?=\\()",
-          "captures": {
+					},
+					"end": "'",
+					"endCaptures": {
 						"1": {
-								"name": "support.function.pine"
+							"name": "punctuation.definition.string.end.pine"
 						}
-					}
-        },
-        {
-          "match": "\\bstrategy\\.(cancel|cancel_all|close|close_all|entry|exit|order)(?=\\()",
-          "captures": {
-						"1": {
-								"name": "support.function.pine"
+					},
+					"name": "string.quoted.single.pine",
+					"patterns": [
+						{
+							"match": "\\\\.",
+							"name": "constant.character.escaped.pine"
 						}
-					}
-        },
-        {
-          "match": "\\bstrategy\\.risk\\.(allow_entry_in|max_cons_loss_days|max_drawdown|max_intraday_filled_orders|max_intraday_loss|max_position_size)(?=\\()",
-          "captures": {
-						"1": {
-								"name": "support.function.pine"
-						}
-					}
-        },
-        {
-          "match": "[a-zA-Z_][a-zA-Z0-9_]*\\s*(?=\\=)",
-          "name": "variable.parameter.pine"
-        },
-        {
-          "match": "([a-zA-Z_][a-zA-Z0-9_]*)\\(.*\\)\\s(=>)\\s",
-          "captures": {
+					]
+				}
+			]
+		},
+		"keywords": {
+			"patterns": [
+				{
+					"match": "\\b(if|else|continue|break|for|while|return|export|import|as)\\b",
+					"name": "keyword.control.pine"
+				}
+			]
+		},
+		"constants": {
+			"patterns": [
+				{
+					"match": "\\b(ta|math|input|array|label|adjustment|barmerge|barstate|currency|color|format|location|scale|session|shape|size|strategy|syminfo)\\b(?!\\()(?=\\.)",
+					"name": "support.class.pine"
+				},
+				{
+					"match": "\\b(risk|commission|direction|oca)\\b(?!\\()(?=\\.)",
+					"name": "support.class.pine"
+				},
+				{
+					"match": "\\b(true|false)\\b(?!\\()",
+					"name": "constant.language.pine"
+				},
+				{
+					"match": "\\b(open|high|low|close|volume|na|period)\\b(?!\\()",
+					"name": "constant.language.pine"
+				},
+				{
+					"match": "\\b(monday|tuesday|wednesday|thursday|friday|saturday|sunday|second|minute|hour|month|dayofweek|dayofmonth|weekofyear|year)\\b(?!\\()",
+					"name": "constant.language.pine"
+				},
+				{
+					"match": "\\b(line|linebr|histogram|cross|area|areabr|columns|circles)\\b(?!\\()",
+					"name": "constant.language.pine"
+				},
+				{
+					"match": "\\bis(daily|dwm|intraday|minutes|monthly|seconds|weekly)?\\b(?!\\()",
+					"name": "constant.language.pine"
+				},
+				{
+					"match": "\\b(string|symbol|bool|integer|int|float|simple|series)\\b(?!\\()",
+					"name": "constant.language.pine"
+				},
+				{
+					"match": "\\b(dotted|dashed)\\b(?!\\()",
+					"name": "constant.language.pine"
+				},
+				{
+					"match": "\\b(aqua|black|silver|gray|white|maroon|red|purple|fuchsia|green|lime|olive|yellow|navy|blue|teal|orange)\\b(?!\\()",
+					"name": "constant.language.pine"
+				},
+				{
+					"match": "\\b(accdist|hl2|hlc3|interval|n|ohlc4|resolution|session|solid|source|stepline|ticker|tickerid|time|timenow|tr|vwap)\\b(?!\\()",
+					"name": "constant.language.pine"
+				},
+				{
+					"match": "\\b(dividends|none|splits|gaps_off|gaps_on|lookahead_off|lookahead_on|isconfirmed|isfirst|ishistory|islast|isnew|isrealtime|AUD|CAD|CHF|EUR|GBP|HKD|JPY|NOK|NONE|NZD|RUB|SEK|SGD|TRY|USD|ZAR|abovebar|absolute|belowbar|bottom|top|left|right|extended|regular|arrowdown|arrowup|circle|diamond|flag|labeldown|labelup|square|triangledown|triangleup|xcross|auto|huge|large|normal|small|tiny|cash|closedtrades|cash_per_contract|cash_per_order|percent|price|all|long|short|equity|eventrades|fixed|grossloss|grossprofit|initial_capital|losstrades|max_contracts_held_all|max_contracts_held_long|max_contracts_held_short|max_drawdown|netprofit|cancel|reduce|openprofit|opentrades|percent_of_equity|position_avg_price|position_entry_name|position_size|wintrades|mintick|pointvalue|prefix|root|timezone)\\b(?!\\()",
+					"name": "constant.language.pine"
+				},
+				{
+					"match": "\\b([0-9]+)\\b",
+					"name": "constant.numeric.pine"
+				},
+				{
+					"match": "#[a-fA-F0-9]{6}",
+					"name": "contstant.other.pine"
+				}
+			]
+		},
+		"variables": {
+			"patterns": [
+				{
+					"match": "[a-zA-Z_][a-zA-Z0-9_]*\\s*(?=\\=)",
+					"name": "variable.other.pine"
+				}
+			]
+		},
+		"functions": {
+			"patterns": [
+				{
+					"match": "\\b(abs|acros|alertcondition|alma|asin|atan|atr|avg|barcolor|barssince|bgcolor|cci|ceil|change|cog|color|correlation|cos|cross|crossover|crossunder|cum|dayofmonth|dayofweek|dev|ema|exp|falling|fill|fixnan|floor|heikinashi|highest|highestbars|hline|hour|iff|indicator|input|kagi|library|linebreak|linreg|log|log10|lowest|lowestbars|macd|max|min|minute|mom|month|na|nz|offset|percentile_linear_interpolation|percentile_nearest_rank|percentrank|pivothigh|pivotlow|plot(arrow|bar|candle|char|shape)?|pointfigure|pow|renko|rising|rma|roc|round|rsi|sar|second|security|sign|sin|sma|sqrt|stdev|stoch|strategy|cancel|cancel_all|close|close_all|entry|exit|order|allow_entry_in|max_cons_loss_days|max_intraday_filled_orders|max_intraday_loss|max_position_size|study|sum|swma|tan|tickerid|time|timestamp|tostring|tr|tsi|valuewhen|variance|vwap|vwma|weekofyear|wma|year)+?(?=\\()",
+					"name": "entity.name.function.pine"
+				},
+				{
+					"match": "([a-zA-Z_][a-zA-Z0-9_]*)\\(.*\\)\\s(=>)\\s",
+					"captures": {
 						"1": {
 							"name": "support.function.pine"
 						},
@@ -133,178 +164,32 @@
 							"name": "keyword.operator.assignment.pine"
 						}
 					}
-        }
-      ]
-    },
-    "constants": {
-      "patterns":[
-        {
-          "match": "\\b(true|false)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\b(accdist|bar_index|close|dayofmonth|dayofweek|high|hl2|hlc3|hour|iii|low|minute|month|na|nvi|obv|ohlc4|open|pvi|pvt|second|time|time_close|timenow|tr|volume|vwap|wad|weekofyear|wvad|year)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\btimeframe\\.(isdaily|isdwm|isintraday|isminutes|ismonthly|isseconds|isweekly|multiplier|period)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\bsyminfo\\.(basecurrency|currency|description|mintick|pointvalue|prefix|root|session|ticker|tickerid|timezone|type)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\bdayofweek\\.(monday|tuesday|wednesday|thursday|friday|saturday|sunday)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\bplot\\.style_(area|areabr|circles|columns|cross|histogram|line|linebr|stepline)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\blocation\\.(abovebar|belowbar|top|bottom|absolute)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\bshape\\.(arrowdown|arrowup|circle|cross|diamond|flag|labeldown|labelup|square|triangledown|triangleup|xcross)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\bcolor\\.(aqua|black|silver|gray|white|maroon|red|purple|fuchsia|green|lime|olive|yellow|navy|blue|teal|orange)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\bcurrency\\.(AUD|CAD|CHF|EUR|GBP|HKD|JPY|NOK|NONE|NZD|RUB|SEK|SGD|TRY|USD|ZAR)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\bbarmerge\\.(gaps_off|gaps_on|lookahead_off|lookahead_on)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\bbarstate\\.(isconfirmed|isfirst|ishistory|islast|isnew|isrealtime)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\badjustment\\.(dividends|none|splits)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\bdisplay\\.(all|none)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\bextend\\.(both|left|none|right)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\bformat\\.(inherit|price|volume)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\bhline\\.style_(dashed|dotted|solid)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\binput\\.(bool|color|float|integer|resolution|session|source|string|symbol)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\blabel\\.style_(arrowdown|arrowup|circle|cross|diamond|flag|label_center|label_down|label_left|label_lower_left|label_lower_right|label_right|label_up|label_upper_left|label_upper_right|none|square|triangledown|triangleup|xcross)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\bline\\.style_(arrow_both|arrow_left|arrow_right|dashed|dotted|solid)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\border\\.(ascending|descending)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\bscale\\.(left|right|none)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\bsession\\.(extended|regular)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\bsize\\.(auto|huge|large|normal|small|tiny)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\bstrategy\\.(cash|closedtrades|equity|eventrades|fixed|grossloss|grossprofit|initial_capital|long|losstrades|max_drawdown|netprofit|openprofit|opentrades|percent_of_equity|position_avg_price|position_entry_name|position_size|short|wintrades)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\bstrategy\\.commission\\.(cash_per_contract|cash_per_order|percent)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\bstrategy\\.direction\\.(all|long|short)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\bstrategy\\.max_contracts_held_(all|long|short)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\bstrategy\\.oca\\.(cancel|none|reduce)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\btext\\.align_(center|left|right)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\bxloc\\.(bar_index|bar_time)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "\\byloc\\.(abovebar|belowbar|price)\\b",
-          "name": "constant.language.pine"
-        },
-        {
-          "match": "#[a-fA-F0-9]{6}",
-          "name": "contstant.support.pine"
-        },
-        {
-          "match": "\\b([0-9]+)\\b",
-          "name": "constant.numeric.pine"
-        }
-      ]
-    },
-    "operators": {
-      "patterns": [
-        {
-          "match": "(\\-|\\+|\\*|/|%)",
-          "name": "keyword.operator.arithmetic.pine"
-        },
-        {
-          "match": "(==|!=|<=|>=|<|>)",
-          "name": "keyword.operator.comparison.pine"
-        },
-        {
-          "match": "(\\?|\\:)",
-          "name": "keyword.operator.ternary.pine"
-        },
-        {
-          "match": "\\b(and|or|not)\\b",
-          "name": "keyword.operator.logical.pine"
-        },
-        {
-          "match": "=",
-          "name": "keyword.operator.assignment.pine"
-        }
-      ]
-    },
-    "keywords": {
-			"patterns": [{
-				"name": "keyword.control.pine",
-				"match": "\\b(if|else|while|for|return)\\b"
-			}]
+				}
+			]
+		},
+		"operators": {
+			"patterns": [
+				{
+					"match": "(\\-|\\+|\\*|/|%)",
+					"name": "keyword.operator.arithmetic.pine"
+				},
+				{
+					"match": "(==|!=|<=|>=|<|>)",
+					"name": "keyword.operator.comparison.pine"
+				},
+				{
+					"match": "(\\?|\\:)",
+					"name": "keyword.operator.ternary.pine"
+				},
+				{
+					"match": "\\b(and|or|not)\\b",
+					"name": "keyword.operator.logical.pine"
+				},
+				{
+					"match": "=",
+					"name": "keyword.operator.assignment.pine"
+				}
+			]
 		}
 	},
 	"scopeName": "source.pine"

--- a/syntaxes/pine.tmLanguage.json
+++ b/syntaxes/pine.tmLanguage.json
@@ -1,196 +1,196 @@
 {
-	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-	"name": "Pine Script",
-	"patterns": [
-		{
-			"match": "//.*",
-			"name": "comment.line.double-slash.pine"
-		},
-		{
-			"include": "#strings"
-		},
-		{
-			"include": "#keywords"
-		},
-		{
-			"include": "#constants"
-		},
-		{
-			"include": "#variables"
-		},
-		{
-			"include": "#functions"
-		},
-		{
-			"include": "#operators"
-		}
-	],
-	"repository": {
-		"strings": {
-			"patterns": [
-				{
-					"begin": "\"",
-					"beginCaptures": {
-						"1": {
-							"name": "punctuation.definition.string.begin.pine"
-						}
-					},
-					"end": "\"",
-					"endCaptures": {
-						"1": {
-							"name": "punctuation.definition.string.end.pine"
-						}
-					},
-					"name": "string.quoted.double.pine",
-					"patterns": [
-						{
-							"match": "\\\\.",
-							"name": "constant.character.escaped.pine"
-						}
-					]
-				},
-				{
-					"begin": "'",
-					"beginCaptures": { 
-						"1": {
-							"name": "punctuation.definition.string.begin.pine"
-						}
-					},
-					"end": "'",
-					"endCaptures": {
-						"1": {
-							"name": "punctuation.definition.string.end.pine"
-						}
-					},
-					"name": "string.quoted.single.pine",
-					"patterns": [
-						{
-							"match": "\\\\.",
-							"name": "constant.character.escaped.pine"
-						}
-					]
-				}
-			]
-		},
-		"keywords": {
-			"patterns": [
-				{
-					"match": "\\b(if|else|continue|break|for|while|return|export|import|as)\\b",
-					"name": "keyword.control.pine"
-				}
-			]
-		},
-		"constants": {
-			"patterns": [
-				{
-					"match": "\\b(ta|math|input|array|label|adjustment|barmerge|barstate|currency|color|format|location|scale|session|shape|size|strategy|syminfo)\\b(?!\\()(?=\\.)",
-					"name": "support.class.pine"
-				},
-				{
-					"match": "\\b(risk|commission|direction|oca)\\b(?!\\()(?=\\.)",
-					"name": "support.class.pine"
-				},
-				{
-					"match": "\\b(true|false)\\b(?!\\()",
-					"name": "constant.language.pine"
-				},
-				{
-					"match": "\\b(open|high|low|close|volume|na|period)\\b(?!\\()",
-					"name": "constant.language.pine"
-				},
-				{
-					"match": "\\b(monday|tuesday|wednesday|thursday|friday|saturday|sunday|second|minute|hour|month|dayofweek|dayofmonth|weekofyear|year)\\b(?!\\()",
-					"name": "constant.language.pine"
-				},
-				{
-					"match": "\\b(line|linebr|histogram|cross|area|areabr|columns|circles)\\b(?!\\()",
-					"name": "constant.language.pine"
-				},
-				{
-					"match": "\\bis(daily|dwm|intraday|minutes|monthly|seconds|weekly)?\\b(?!\\()",
-					"name": "constant.language.pine"
-				},
-				{
-					"match": "\\b(string|symbol|bool|integer|int|float|simple|series)\\b(?!\\()",
-					"name": "constant.language.pine"
-				},
-				{
-					"match": "\\b(dotted|dashed)\\b(?!\\()",
-					"name": "constant.language.pine"
-				},
-				{
-					"match": "\\b(aqua|black|silver|gray|white|maroon|red|purple|fuchsia|green|lime|olive|yellow|navy|blue|teal|orange)\\b(?!\\()",
-					"name": "constant.language.pine"
-				},
-				{
-					"match": "\\b(accdist|hl2|hlc3|interval|n|ohlc4|resolution|session|solid|source|stepline|ticker|tickerid|time|timenow|tr|vwap)\\b(?!\\()",
-					"name": "constant.language.pine"
-				},
-				{
-					"match": "\\b(dividends|none|splits|gaps_off|gaps_on|lookahead_off|lookahead_on|isconfirmed|isfirst|ishistory|islast|isnew|isrealtime|AUD|CAD|CHF|EUR|GBP|HKD|JPY|NOK|NONE|NZD|RUB|SEK|SGD|TRY|USD|ZAR|abovebar|absolute|belowbar|bottom|top|left|right|extended|regular|arrowdown|arrowup|circle|diamond|flag|labeldown|labelup|square|triangledown|triangleup|xcross|auto|huge|large|normal|small|tiny|cash|closedtrades|cash_per_contract|cash_per_order|percent|price|all|long|short|equity|eventrades|fixed|grossloss|grossprofit|initial_capital|losstrades|max_contracts_held_all|max_contracts_held_long|max_contracts_held_short|max_drawdown|netprofit|cancel|reduce|openprofit|opentrades|percent_of_equity|position_avg_price|position_entry_name|position_size|wintrades|mintick|pointvalue|prefix|root|timezone)\\b(?!\\()",
-					"name": "constant.language.pine"
-				},
-				{
-					"match": "\\b([0-9]+)\\b",
-					"name": "constant.numeric.pine"
-				},
-				{
-					"match": "#[a-fA-F0-9]{6}",
-					"name": "contstant.other.pine"
-				}
-			]
-		},
-		"variables": {
-			"patterns": [
-				{
-					"match": "[a-zA-Z_][a-zA-Z0-9_]*\\s*(?=\\=)",
-					"name": "variable.other.pine"
-				}
-			]
-		},
-		"functions": {
-			"patterns": [
-				{
-					"match": "\\b(abs|acros|alertcondition|alma|asin|atan|atr|avg|barcolor|barssince|bgcolor|cci|ceil|change|cog|color|correlation|cos|cross|crossover|crossunder|cum|dayofmonth|dayofweek|dev|ema|exp|falling|fill|fixnan|floor|heikinashi|highest|highestbars|hline|hour|iff|indicator|input|kagi|library|linebreak|linreg|log|log10|lowest|lowestbars|macd|max|min|minute|mom|month|na|nz|offset|percentile_linear_interpolation|percentile_nearest_rank|percentrank|pivothigh|pivotlow|plot(arrow|bar|candle|char|shape)?|pointfigure|pow|renko|rising|rma|roc|round|rsi|sar|second|security|sign|sin|sma|sqrt|stdev|stoch|strategy|cancel|cancel_all|close|close_all|entry|exit|order|allow_entry_in|max_cons_loss_days|max_intraday_filled_orders|max_intraday_loss|max_position_size|study|sum|swma|tan|tickerid|time|timestamp|tostring|tr|tsi|valuewhen|variance|vwap|vwma|weekofyear|wma|year)+?(?=\\()",
-					"name": "entity.name.function.pine"
-				},
-				{
-					"match": "([a-zA-Z_][a-zA-Z0-9_]*)\\(.*\\)\\s(=>)\\s",
-					"captures": {
-						"1": {
-							"name": "support.function.pine"
-						},
-						"2": {
-							"name": "keyword.operator.assignment.pine"
-						}
-					}
-				}
-			]
-		},
-		"operators": {
-			"patterns": [
-				{
-					"match": "(\\-|\\+|\\*|/|%)",
-					"name": "keyword.operator.arithmetic.pine"
-				},
-				{
-					"match": "(==|!=|<=|>=|<|>)",
-					"name": "keyword.operator.comparison.pine"
-				},
-				{
-					"match": "(\\?|\\:)",
-					"name": "keyword.operator.ternary.pine"
-				},
-				{
-					"match": "\\b(and|or|not)\\b",
-					"name": "keyword.operator.logical.pine"
-				},
-				{
-					"match": "=",
-					"name": "keyword.operator.assignment.pine"
-				}
-			]
-		}
-	},
-	"scopeName": "source.pine"
+    "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+    "name": "Pine Script",
+    "patterns": [
+        {
+            "match": "//.*",
+            "name": "comment.line.double-slash.pine"
+        },
+        {
+            "include": "#strings"
+        },
+        {
+            "include": "#keywords"
+        },
+        {
+            "include": "#constants"
+        },
+        {
+            "include": "#variables"
+        },
+        {
+            "include": "#functions"
+        },
+        {
+            "include": "#operators"
+        }
+    ],
+    "repository": {
+        "strings": {
+            "patterns": [
+                {
+                    "begin": "\"",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.string.begin.pine"
+                        }
+                    },
+                    "end": "\"",
+                    "endCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.string.end.pine"
+                        }
+                    },
+                    "name": "string.quoted.double.pine",
+                    "patterns": [
+                        {
+                            "match": "\\\\.",
+                            "name": "constant.character.escaped.pine"
+                        }
+                    ]
+                },
+                {
+                    "begin": "'",
+                    "beginCaptures": { 
+                        "1": {
+                            "name": "punctuation.definition.string.begin.pine"
+                        }
+                    },
+                    "end": "'",
+                    "endCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.string.end.pine"
+                        }
+                    },
+                    "name": "string.quoted.single.pine",
+                    "patterns": [
+                        {
+                            "match": "\\\\.",
+                            "name": "constant.character.escaped.pine"
+                        }
+                    ]
+                }
+            ]
+        },
+        "keywords": {
+            "patterns": [
+                {
+                    "match": "\\b(if|else|continue|break|for|while|return|export|import|as)\\b",
+                    "name": "keyword.control.pine"
+                }
+            ]
+        },
+        "constants": {
+            "patterns": [
+                {
+                    "match": "\\b(ta|math|input|array|label|adjustment|barmerge|barstate|currency|color|format|location|scale|session|shape|size|strategy|syminfo)\\b(?!\\()(?=\\.)",
+                    "name": "support.class.pine"
+                },
+                {
+                    "match": "\\b(risk|commission|direction|oca)\\b(?!\\()(?=\\.)",
+                    "name": "support.class.pine"
+                },
+                {
+                    "match": "\\b(true|false)\\b(?!\\()",
+                    "name": "constant.language.pine"
+                },
+                {
+                    "match": "\\b(open|high|low|close|volume|na|period)\\b(?!\\()",
+                    "name": "constant.language.pine"
+                },
+                {
+                    "match": "\\b(monday|tuesday|wednesday|thursday|friday|saturday|sunday|second|minute|hour|month|dayofweek|dayofmonth|weekofyear|year)\\b(?!\\()",
+                    "name": "constant.language.pine"
+                },
+                {
+                    "match": "\\b(line|linebr|histogram|cross|area|areabr|columns|circles)\\b(?!\\()",
+                    "name": "constant.language.pine"
+                },
+                {
+                    "match": "\\bis(daily|dwm|intraday|minutes|monthly|seconds|weekly)?\\b(?!\\()",
+                    "name": "constant.language.pine"
+                },
+                {
+                    "match": "\\b(string|symbol|bool|integer|int|float|simple|series)\\b(?!\\()",
+                    "name": "constant.language.pine"
+                },
+                {
+                    "match": "\\b(dotted|dashed)\\b(?!\\()",
+                    "name": "constant.language.pine"
+                },
+                {
+                    "match": "\\b(aqua|black|silver|gray|white|maroon|red|purple|fuchsia|green|lime|olive|yellow|navy|blue|teal|orange)\\b(?!\\()",
+                    "name": "constant.language.pine"
+                },
+                {
+                    "match": "\\b(accdist|hl2|hlc3|interval|n|ohlc4|resolution|session|solid|source|stepline|ticker|tickerid|time|timenow|tr|vwap)\\b(?!\\()",
+                    "name": "constant.language.pine"
+                },
+                {
+                    "match": "\\b(dividends|none|splits|gaps_off|gaps_on|lookahead_off|lookahead_on|isconfirmed|isfirst|ishistory|islast|isnew|isrealtime|AUD|CAD|CHF|EUR|GBP|HKD|JPY|NOK|NONE|NZD|RUB|SEK|SGD|TRY|USD|ZAR|abovebar|absolute|belowbar|bottom|top|left|right|extended|regular|arrowdown|arrowup|circle|diamond|flag|labeldown|labelup|square|triangledown|triangleup|xcross|auto|huge|large|normal|small|tiny|cash|closedtrades|cash_per_contract|cash_per_order|percent|price|all|long|short|equity|eventrades|fixed|grossloss|grossprofit|initial_capital|losstrades|max_contracts_held_all|max_contracts_held_long|max_contracts_held_short|max_drawdown|netprofit|cancel|reduce|openprofit|opentrades|percent_of_equity|position_avg_price|position_entry_name|position_size|wintrades|mintick|pointvalue|prefix|root|timezone)\\b(?!\\()",
+                    "name": "constant.language.pine"
+                },
+                {
+                    "match": "\\b([0-9]+)\\b",
+                    "name": "constant.numeric.pine"
+                },
+                {
+                    "match": "#[a-fA-F0-9]{6}",
+                    "name": "contstant.other.pine"
+                }
+            ]
+        },
+        "variables": {
+            "patterns": [
+                {
+                    "match": "[a-zA-Z_][a-zA-Z0-9_]*\\s*(?=\\=)",
+                    "name": "variable.other.pine"
+                }
+            ]
+        },
+        "functions": {
+            "patterns": [
+                {
+                    "match": "\\b(abs|acros|alertcondition|alma|asin|atan|atr|avg|barcolor|barssince|bgcolor|cci|ceil|change|cog|color|correlation|cos|cross|crossover|crossunder|cum|dayofmonth|dayofweek|dev|ema|exp|falling|fill|fixnan|floor|heikinashi|highest|highestbars|hline|hour|iff|indicator|input|kagi|library|linebreak|linreg|log|log10|lowest|lowestbars|macd|max|min|minute|mom|month|na|nz|offset|percentile_linear_interpolation|percentile_nearest_rank|percentrank|pivothigh|pivotlow|plot(arrow|bar|candle|char|shape)?|pointfigure|pow|renko|rising|rma|roc|round|rsi|sar|second|security|sign|sin|sma|sqrt|stdev|stoch|strategy|cancel|cancel_all|close|close_all|entry|exit|order|allow_entry_in|max_cons_loss_days|max_intraday_filled_orders|max_intraday_loss|max_position_size|study|sum|swma|tan|tickerid|time|timestamp|tostring|tr|tsi|valuewhen|variance|vwap|vwma|weekofyear|wma|year)+?(?=\\()",
+                    "name": "entity.name.function.pine"
+                },
+                {
+                    "match": "([a-zA-Z_][a-zA-Z0-9_]*)\\(.*\\)\\s(=>)\\s",
+                    "captures": {
+                        "1": {
+                            "name": "support.function.pine"
+                        },
+                        "2": {
+                            "name": "keyword.operator.assignment.pine"
+                        }
+                    }
+                }
+            ]
+        },
+        "operators": {
+            "patterns": [
+                {
+                    "match": "(\\-|\\+|\\*|/|%)",
+                    "name": "keyword.operator.arithmetic.pine"
+                },
+                {
+                    "match": "(==|!=|<=|>=|<|>)",
+                    "name": "keyword.operator.comparison.pine"
+                },
+                {
+                    "match": "(\\?|\\:)",
+                    "name": "keyword.operator.ternary.pine"
+                },
+                {
+                    "match": "\\b(and|or|not)\\b",
+                    "name": "keyword.operator.logical.pine"
+                },
+                {
+                    "match": "=",
+                    "name": "keyword.operator.assignment.pine"
+                }
+            ]
+        }
+    },
+    "scopeName": "source.pine"
 }


### PR DESCRIPTION
The formatting was inconsistent so I CTRL-ALT-F in VS Code.
If you need to see the specific diff, ignoring whitespace differences would be the way.